### PR TITLE
fix: Set group and version properly to fix publishing job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,8 @@
 plugins {
     id 'nva.language.core.rootplugin'
 }
+
+allprojects {
+    group = getProperty("GROUP")
+    version = getProperty("VERSION_NAME")
+}

--- a/buildSrc/src/main/groovy/nva.language.core.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.language.core.java-conventions.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'maven-publish'
 }
 
-group = 'com.github.bibsysdev'
-version = '1.2.2'
-
 nva {
     errorprone {
         allErrorsAsWarnings = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,10 @@ org.gradle.warning.mode=all
 # Allow Gradle to use more memory than the default (needed for buildHealth command)
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
+# Maven publishing coordinates
+GROUP=com.github.bibsysdev
+VERSION_NAME=1.2.2
+
 # Version of `nva-commons` used for version catalog and dependencies
 nvaCommonsVersion=2.8.2
 


### PR DESCRIPTION
Sets `group` and `version` properties globally (all projects), matching `nva-commons`. This is necessary to make the CI publishing job for Maven Central work.